### PR TITLE
Update "(07-31-2018)"

### DIFF
--- a/zht/run_mods.json
+++ b/zht/run_mods.json
@@ -108,19 +108,19 @@
     "DESCRIPTION": "在無盡模式第一次完成第三階段後，敵人不再掉落牌"
   },
   "Blue Cards": {
-    "NAME": "Blue Cards",
-    "DESCRIPTION": "Blue cards now appear in rewards and shops."
+    "NAME": "藍色牌",
+    "DESCRIPTION": "卡牌獎勵與商店會出現藍色牌"
   },
   "Red Cards": {
-    "NAME": "Red Cards",
-    "DESCRIPTION": "Red cards now appear in rewards and shops."
+    "NAME": "紅色牌",
+    "DESCRIPTION": "卡牌獎勵與商店會出現紅色牌"
   },
   "Colorless Cards": {
-    "NAME": "Colorless Cards",
-    "DESCRIPTION": "Colorless cards appear more often."
+    "NAME": "無色牌",
+    "DESCRIPTION": "無色牌會更加頻繁地出現"
   },
   "Green Cards": {
-    "NAME": "Green Cards",
-    "DESCRIPTION": "Green cards now appear in rewards and shops."
+    "NAME": "綠色牌",
+    "DESCRIPTION": "卡牌獎勵與商店會出現綠色牌"
   }
 }


### PR DESCRIPTION
Update new mods "Blue Cards", "Red Cards", "Colorless Cards" and "Green Cards"

目前 ```Colorless Cards``` 都翻作 ```無色牌```，因此三個顏色也翻作 ```X色牌``` 而非 ```X色卡牌```